### PR TITLE
Set up local Windows dev workflow and cron sync logging

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,37 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Start Pocketbase",
+            "label": "Start PocketBase",
             "type": "shell",
-            "command": "/pb/pocketbase serve --http=${PB_HTTP_ADDR} --dir=${PB_DATA_DIR} --hooksDir=${PB_HOOKS_DIR} --migrationsDir=${PB_MIGRATIONS_DIR} --publicDir=${PB_PUBLIC_DIR}",
+            "command": "cd pocketbase && .\\pocketbase.exe serve --http=0.0.0.0:8090 --dir=pb_data --hooksDir=pb_hooks --migrationsDir=pb_migrations",
             "group": "build",
-            "detail": "Start Pocketbase server"
+            "detail": "Start PocketBase server (http://localhost:8090)",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "isBackground": true
+        },
+        {
+            "label": "Start Dev Server",
+            "type": "shell",
+            "command": "npm run dev",
+            "group": "build",
+            "detail": "Start Vite React dev server (http://localhost:3000)",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "isBackground": true
+        },
+        {
+            "label": "Start All (Dev)",
+            "dependsOn": ["Start PocketBase", "Start Dev Server"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Start both PocketBase and the React dev server"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "pocketbase": "cd pocketbase && ./pocketbase serve --http=0.0.0.0:8090",
+    "pocketbase": "cd pocketbase && .\\pocketbase.exe serve --http=0.0.0.0:8090 --dir=pb_data --hooksDir=pb_hooks --migrationsDir=pb_migrations",
     "setup": "powershell -ExecutionPolicy Bypass -File ./scripts/dev-setup.ps1",
     "docker:build": "docker build -t spell-binder .",
     "docker:run": "docker run -p 8080:8080 spell-binder",

--- a/pocketbase/pb_hooks/sync.js
+++ b/pocketbase/pb_hooks/sync.js
@@ -3,6 +3,28 @@ const BATCH_SIZE = 1000 // Process cards in batches to avoid memory issues
 const MAX_RETRIES = 3
 const RETRY_DELAY = 5000 // 5 seconds
 
+function logCronEvent(jobName, status, message, recordsProcessed = null, details = null) {
+    try {
+        const logsCollection = $app.findCollectionByNameOrId("cron_logs")
+        const logRecord = new Record(logsCollection)
+        logRecord.set("job_name", jobName)
+        logRecord.set("status", status)
+        logRecord.set("message", message)
+
+        if (recordsProcessed !== null) {
+            logRecord.set("records_processed", recordsProcessed)
+        }
+
+        if (details !== null) {
+            logRecord.set("details", details)
+        }
+
+        $app.saveNoValidate(logRecord)
+    } catch (error) {
+        console.error("Failed to write cron log: " + error.message)
+    }
+}
+
 function makeRequest(url, retries = MAX_RETRIES) {
     try {
         const response = $http.send({
@@ -380,8 +402,9 @@ function batchProcessPrices(priceData, batchNumber, totalBatches) {
 }
 
 // Main sync function to download and process bulk card data
-function syncBulkCardData() {
+function syncBulkCardData(jobName = "manual_sync") {
     console.log("Starting bulk card data synchronization...")
+    logCronEvent(jobName, "started", "Bulk card data synchronization started")
     updateSyncStatus("cards", "in_progress", 0)
 
     try {
@@ -421,6 +444,7 @@ function syncBulkCardData() {
         // Mark sync as complete
         updateSyncStatus("cards", "success", totalProcessed)
         console.log(`Bulk card data sync completed successfully: ${totalProcessed} cards processed`)
+        logCronEvent(jobName, "success", `Bulk card data sync completed successfully: ${totalProcessed} cards processed`, totalProcessed)
 
         // Trigger image sync for cards that need images
         try {
@@ -455,6 +479,7 @@ function syncBulkCardData() {
         const errorMessage = `Bulk sync failed: ${error.message}`
         console.error(errorMessage)
         updateSyncStatus("cards", "failed", 0, errorMessage)
+        logCronEvent(jobName, "failed", errorMessage, 0, { error: error.message })
 
         return {
             success: false,
@@ -533,6 +558,6 @@ function downloadCardImage(cardId, imageUrl, retries = 2) {
 }
 
 module.exports = {
-    syncBulkCardData: () => syncBulkCardData(),
+    syncBulkCardData: (jobName) => syncBulkCardData(jobName),
     downloadCardImage: (cardId, imageUrl, retries) => downloadCardImage(cardId, imageUrl, retries)
 }

--- a/pocketbase/pb_hooks/sync.pb.js
+++ b/pocketbase/pb_hooks/sync.pb.js
@@ -7,5 +7,5 @@ cronAdd("daily_sync", "0 2 * * *", () => {
     console.log("Daily sync job triggered")
 
     const sync = require(`${__hooks}/sync.js`)
-    sync.syncBulkCardData();
+    sync.syncBulkCardData("daily_sync");
 });

--- a/pocketbase/pb_migrations/1760010000_created_cron_logs.js
+++ b/pocketbase/pb_migrations/1760010000_created_cron_logs.js
@@ -1,0 +1,56 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+    const cronLogsCollection = new Collection({
+        "name": "cron_logs",
+        "type": "base",
+        "system": false,
+        "listRule": "",
+        "viewRule": "",
+        "fields": [
+            {
+                "name": "job_name",
+                "type": "text",
+                "required": true,
+                "min": 1,
+                "max": 100
+            },
+            {
+                "name": "status",
+                "type": "select",
+                "required": true,
+                "values": [
+                    "started",
+                    "success",
+                    "failed"
+                ]
+            },
+            {
+                "name": "message",
+                "type": "text",
+                "required": true,
+                "max": 2000
+            },
+            {
+                "name": "records_processed",
+                "type": "number",
+                "required": false,
+                "min": 0
+            },
+            {
+                "name": "details",
+                "type": "json",
+                "required": false
+            }
+        ],
+        "indexes": [
+            "CREATE INDEX idx_cron_logs_job_name ON cron_logs (job_name)",
+            "CREATE INDEX idx_cron_logs_status ON cron_logs (status)"
+        ]
+    })
+
+    app.save(cronLogsCollection)
+}, (app) => {
+    const cronLogsCollection = app.findCollectionByNameOrId("cron_logs")
+    app.delete(cronLogsCollection)
+})

--- a/scripts/dev-setup.ps1
+++ b/scripts/dev-setup.ps1
@@ -1,0 +1,62 @@
+# dev-setup.ps1 - Sets up the local development environment for Spell Binder on Windows
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Split-Path -Parent $scriptDir
+$pbVersion = "0.28.4"
+
+Write-Host "=== Spell Binder Dev Setup ===" -ForegroundColor Cyan
+
+# 1. Create .env if it doesn't exist
+$envFile = Join-Path $projectRoot ".env"
+$envExample = Join-Path $projectRoot ".env.example"
+if (-not (Test-Path $envFile)) {
+    Copy-Item $envExample $envFile
+    $rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+    $bytes = New-Object byte[] 32
+    $rng.GetBytes($bytes)
+    $key = [Convert]::ToBase64String($bytes)
+    (Get-Content $envFile) -replace 'your-secure-encryption-key-here-32-chars-minimum', $key | Set-Content $envFile
+    Write-Host "[OK] Created .env with a generated encryption key" -ForegroundColor Green
+} else {
+    Write-Host "[SKIP] .env already exists" -ForegroundColor Yellow
+}
+
+# 2. Download PocketBase for Windows if not present
+$pbDir = Join-Path $projectRoot "pocketbase"
+$pbExe = Join-Path $pbDir "pocketbase.exe"
+if (-not (Test-Path $pbExe)) {
+    Write-Host "Downloading PocketBase v$pbVersion for Windows..." -ForegroundColor Cyan
+    $pbUrl = "https://github.com/pocketbase/pocketbase/releases/download/v$pbVersion/pocketbase_${pbVersion}_windows_amd64.zip"
+    $zipPath = Join-Path $pbDir "pocketbase.zip"
+    Invoke-WebRequest -Uri $pbUrl -OutFile $zipPath -UseBasicParsing
+    Expand-Archive -Path $zipPath -DestinationPath $pbDir -Force
+    Remove-Item $zipPath
+    Write-Host "[OK] PocketBase v$pbVersion downloaded" -ForegroundColor Green
+} else {
+    Write-Host "[SKIP] PocketBase already exists" -ForegroundColor Yellow
+}
+
+# 3. Install npm dependencies
+Write-Host "Installing npm dependencies..." -ForegroundColor Cyan
+Set-Location $projectRoot
+npm install
+Write-Host "[OK] npm dependencies installed" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "=== Setup Complete! ===" -ForegroundColor Green
+Write-Host ""
+Write-Host "Start the dev servers in two separate terminals:" -ForegroundColor White
+Write-Host ""
+Write-Host "  Terminal 1 (PocketBase):" -ForegroundColor Yellow
+Write-Host "    npm run pocketbase" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Terminal 2 (React dev server):" -ForegroundColor Yellow
+Write-Host "    npm run dev" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Then open:" -ForegroundColor White
+Write-Host "  App:              http://localhost:3000" -ForegroundColor Cyan
+Write-Host "  PocketBase Admin: http://localhost:8090/_/" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "On first run, visit the PocketBase admin to create an admin account." -ForegroundColor Yellow


### PR DESCRIPTION
This branch makes local manual testing easier on Windows and adds persistent observability for the daily card sync job. The repo had a missing local setup path for Windows and cron sync status was only visible in console output.

## What changed
- Added a Windows setup script at `scripts/dev-setup.ps1` to bootstrap `.env`, download PocketBase, and install npm dependencies.
- Updated local run commands for Windows:
  - `package.json` `pocketbase` script now runs `pocketbase.exe` with explicit data/hooks/migrations dirs.
  - `.vscode/tasks.json` now includes Windows-friendly PocketBase + Vite tasks and a combined "Start All (Dev)" task.
- Added cron logging support for sync runs:
  - New migration `1760010000_created_cron_logs.js` creates `cron_logs`.
  - `sync.pb.js` passes the cron job name (`daily_sync`) into the sync flow.
  - `sync.js` now writes `started`/`success`/`failed` log records with message, processed count, and optional details.

## Notes for reviewers
- The cron log write path is intentionally wrapped so sync behavior continues even if log persistence fails.
- `cron_logs` is append-only run history; existing `sync_status` remains the latest-state snapshot.