### PR TITLE
Fix add-to-deck set and type filters

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,37 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Start Pocketbase",
+            "label": "Start PocketBase",
             "type": "shell",
-            "command": "/pb/pocketbase serve --http=${PB_HTTP_ADDR} --dir=${PB_DATA_DIR} --hooksDir=${PB_HOOKS_DIR} --migrationsDir=${PB_MIGRATIONS_DIR} --publicDir=${PB_PUBLIC_DIR}",
+            "command": "cd pocketbase && .\\pocketbase.exe serve --http=0.0.0.0:8090 --dir=pb_data --hooksDir=pb_hooks --migrationsDir=pb_migrations",
             "group": "build",
-            "detail": "Start Pocketbase server"
+            "detail": "Start PocketBase server (http://localhost:8090)",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "isBackground": true
+        },
+        {
+            "label": "Start Dev Server",
+            "type": "shell",
+            "command": "npm run dev",
+            "group": "build",
+            "detail": "Start Vite React dev server (http://localhost:3000)",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "isBackground": true
+        },
+        {
+            "label": "Start All (Dev)",
+            "dependsOn": ["Start PocketBase", "Start Dev Server"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Start both PocketBase and the React dev server"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "pocketbase": "cd pocketbase && ./pocketbase serve --http=0.0.0.0:8090",
+    "pocketbase": "cd pocketbase && .\\pocketbase.exe serve --http=0.0.0.0:8090 --dir=pb_data --hooksDir=pb_hooks --migrationsDir=pb_migrations",
     "setup": "powershell -ExecutionPolicy Bypass -File ./scripts/dev-setup.ps1",
     "docker:build": "docker build -t spell-binder .",
     "docker:run": "docker run -p 8080:8080 spell-binder",

--- a/pocketbase/pb_hooks/api.pb.js
+++ b/pocketbase/pb_hooks/api.pb.js
@@ -49,8 +49,8 @@ routerAdd("GET", "/api/cards", (e) => {
             JOIN cards c ON c.scryfall_id = s.card_id
             WHERE 
                 search_text_fts MATCH {:searchText}
-                AND ({:setCode} IS NULL OR c.set_code = {:setCode})
-                AND ({:typeLine} IS NULL OR c.type_line = {:typeLine})
+                AND ({:setCode} IS NULL OR lower(c.set_code) = lower({:setCode}))
+                AND ({:typeLine} IS NULL OR lower(c.type_line) LIKE '%' || lower({:typeLine}) || '%')
                 AND ({:rarity} IS NULL OR c.rarity = {:rarity})
                 AND ({:colorsIsNull} IS NULL OR EXISTS (
                         SELECT 1

--- a/pocketbase/pb_hooks/sync.js
+++ b/pocketbase/pb_hooks/sync.js
@@ -3,6 +3,28 @@ const BATCH_SIZE = 1000 // Process cards in batches to avoid memory issues
 const MAX_RETRIES = 3
 const RETRY_DELAY = 5000 // 5 seconds
 
+function logCronEvent(jobName, status, message, recordsProcessed = null, details = null) {
+    try {
+        const logsCollection = $app.findCollectionByNameOrId("cron_logs")
+        const logRecord = new Record(logsCollection)
+        logRecord.set("job_name", jobName)
+        logRecord.set("status", status)
+        logRecord.set("message", message)
+
+        if (recordsProcessed !== null) {
+            logRecord.set("records_processed", recordsProcessed)
+        }
+
+        if (details !== null) {
+            logRecord.set("details", details)
+        }
+
+        $app.saveNoValidate(logRecord)
+    } catch (error) {
+        console.error("Failed to write cron log: " + error.message)
+    }
+}
+
 function makeRequest(url, retries = MAX_RETRIES) {
     try {
         const response = $http.send({
@@ -380,8 +402,9 @@ function batchProcessPrices(priceData, batchNumber, totalBatches) {
 }
 
 // Main sync function to download and process bulk card data
-function syncBulkCardData() {
+function syncBulkCardData(jobName = "manual_sync") {
     console.log("Starting bulk card data synchronization...")
+    logCronEvent(jobName, "started", "Bulk card data synchronization started")
     updateSyncStatus("cards", "in_progress", 0)
 
     try {
@@ -421,6 +444,7 @@ function syncBulkCardData() {
         // Mark sync as complete
         updateSyncStatus("cards", "success", totalProcessed)
         console.log(`Bulk card data sync completed successfully: ${totalProcessed} cards processed`)
+        logCronEvent(jobName, "success", `Bulk card data sync completed successfully: ${totalProcessed} cards processed`, totalProcessed)
 
         // Trigger image sync for cards that need images
         try {
@@ -455,6 +479,7 @@ function syncBulkCardData() {
         const errorMessage = `Bulk sync failed: ${error.message}`
         console.error(errorMessage)
         updateSyncStatus("cards", "failed", 0, errorMessage)
+        logCronEvent(jobName, "failed", errorMessage, 0, { error: error.message })
 
         return {
             success: false,
@@ -533,6 +558,6 @@ function downloadCardImage(cardId, imageUrl, retries = 2) {
 }
 
 module.exports = {
-    syncBulkCardData: () => syncBulkCardData(),
+    syncBulkCardData: (jobName) => syncBulkCardData(jobName),
     downloadCardImage: (cardId, imageUrl, retries) => downloadCardImage(cardId, imageUrl, retries)
 }

--- a/pocketbase/pb_hooks/sync.pb.js
+++ b/pocketbase/pb_hooks/sync.pb.js
@@ -7,5 +7,5 @@ cronAdd("daily_sync", "0 2 * * *", () => {
     console.log("Daily sync job triggered")
 
     const sync = require(`${__hooks}/sync.js`)
-    sync.syncBulkCardData();
+    sync.syncBulkCardData("daily_sync");
 });

--- a/pocketbase/pb_migrations/1760010000_created_cron_logs.js
+++ b/pocketbase/pb_migrations/1760010000_created_cron_logs.js
@@ -1,0 +1,56 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((app) => {
+    const cronLogsCollection = new Collection({
+        "name": "cron_logs",
+        "type": "base",
+        "system": false,
+        "listRule": "",
+        "viewRule": "",
+        "fields": [
+            {
+                "name": "job_name",
+                "type": "text",
+                "required": true,
+                "min": 1,
+                "max": 100
+            },
+            {
+                "name": "status",
+                "type": "select",
+                "required": true,
+                "values": [
+                    "started",
+                    "success",
+                    "failed"
+                ]
+            },
+            {
+                "name": "message",
+                "type": "text",
+                "required": true,
+                "max": 2000
+            },
+            {
+                "name": "records_processed",
+                "type": "number",
+                "required": false,
+                "min": 0
+            },
+            {
+                "name": "details",
+                "type": "json",
+                "required": false
+            }
+        ],
+        "indexes": [
+            "CREATE INDEX idx_cron_logs_job_name ON cron_logs (job_name)",
+            "CREATE INDEX idx_cron_logs_status ON cron_logs (status)"
+        ]
+    })
+
+    app.save(cronLogsCollection)
+}, (app) => {
+    const cronLogsCollection = app.findCollectionByNameOrId("cron_logs")
+    app.delete(cronLogsCollection)
+})

--- a/scripts/dev-setup.ps1
+++ b/scripts/dev-setup.ps1
@@ -1,0 +1,62 @@
+# dev-setup.ps1 - Sets up the local development environment for Spell Binder on Windows
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Split-Path -Parent $scriptDir
+$pbVersion = "0.28.4"
+
+Write-Host "=== Spell Binder Dev Setup ===" -ForegroundColor Cyan
+
+# 1. Create .env if it doesn't exist
+$envFile = Join-Path $projectRoot ".env"
+$envExample = Join-Path $projectRoot ".env.example"
+if (-not (Test-Path $envFile)) {
+    Copy-Item $envExample $envFile
+    $rng = [System.Security.Cryptography.RNGCryptoServiceProvider]::new()
+    $bytes = New-Object byte[] 32
+    $rng.GetBytes($bytes)
+    $key = [Convert]::ToBase64String($bytes)
+    (Get-Content $envFile) -replace 'your-secure-encryption-key-here-32-chars-minimum', $key | Set-Content $envFile
+    Write-Host "[OK] Created .env with a generated encryption key" -ForegroundColor Green
+} else {
+    Write-Host "[SKIP] .env already exists" -ForegroundColor Yellow
+}
+
+# 2. Download PocketBase for Windows if not present
+$pbDir = Join-Path $projectRoot "pocketbase"
+$pbExe = Join-Path $pbDir "pocketbase.exe"
+if (-not (Test-Path $pbExe)) {
+    Write-Host "Downloading PocketBase v$pbVersion for Windows..." -ForegroundColor Cyan
+    $pbUrl = "https://github.com/pocketbase/pocketbase/releases/download/v$pbVersion/pocketbase_${pbVersion}_windows_amd64.zip"
+    $zipPath = Join-Path $pbDir "pocketbase.zip"
+    Invoke-WebRequest -Uri $pbUrl -OutFile $zipPath -UseBasicParsing
+    Expand-Archive -Path $zipPath -DestinationPath $pbDir -Force
+    Remove-Item $zipPath
+    Write-Host "[OK] PocketBase v$pbVersion downloaded" -ForegroundColor Green
+} else {
+    Write-Host "[SKIP] PocketBase already exists" -ForegroundColor Yellow
+}
+
+# 3. Install npm dependencies
+Write-Host "Installing npm dependencies..." -ForegroundColor Cyan
+Set-Location $projectRoot
+npm install
+Write-Host "[OK] npm dependencies installed" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "=== Setup Complete! ===" -ForegroundColor Green
+Write-Host ""
+Write-Host "Start the dev servers in two separate terminals:" -ForegroundColor White
+Write-Host ""
+Write-Host "  Terminal 1 (PocketBase):" -ForegroundColor Yellow
+Write-Host "    npm run pocketbase" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Terminal 2 (React dev server):" -ForegroundColor Yellow
+Write-Host "    npm run dev" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Then open:" -ForegroundColor White
+Write-Host "  App:              http://localhost:3000" -ForegroundColor Cyan
+Write-Host "  PocketBase Admin: http://localhost:8090/_/" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "On first run, visit the PocketBase admin to create an admin account." -ForegroundColor Yellow

--- a/src/components/AddCardModal.tsx
+++ b/src/components/AddCardModal.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useRef } from 'react'
 import Modal from './Modal'
 import CardImage from './CardImage'
 import LoadingSpinner from './LoadingSpinner'
-import { Card, DeckCard, DeckCardType, Deck } from '../lib/types'
+import { Card, CardFilters, DeckCard, DeckCardType, Deck } from '../lib/types'
 import { getDeckConstraints, getMaxQuantityForCard, isCommanderSlotAvailable } from '../lib/deckConstraints'
-import { getEDHRECRecommendations } from '../lib/api'
+import { getCardSets, getEDHRECRecommendations } from '../lib/api'
 
 interface AddCardModalProps {
     isOpen: boolean
@@ -16,6 +16,8 @@ interface AddCardModalProps {
     allCards: Card[]
     searchQuery: string
     setSearchQuery: (query: string) => void
+    searchFilters: Pick<CardFilters, 'set' | 'type'>
+    setSearchFilters: (filters: Pick<CardFilters, 'set' | 'type'>) => void
     searchInCollection: boolean
     setSearchInCollection: (value: boolean) => void
     isSearchingAllCards: boolean
@@ -35,6 +37,8 @@ export default function AddCardModal({
     allCards,
     searchQuery,
     setSearchQuery,
+    searchFilters,
+    setSearchFilters,
     searchInCollection,
     setSearchInCollection,
     isSearchingAllCards,
@@ -52,7 +56,10 @@ export default function AddCardModal({
     const [edhrecRecommendations, setEdhrecRecommendations] = useState<Card[]>([])
     const [edhrecLoading, setEdhrecLoading] = useState(false)
     const [onlyFromCollection, setOnlyFromCollection] = useState(false)
+    const [setOptions, setSetOptions] = useState<{ code: string, name: string }[]>([])
+    const [isLoadingSetOptions, setIsLoadingSetOptions] = useState(false)
     const buttonRef = useRef<HTMLButtonElement>(null)
+    const typeOptions = ['Land', 'Creature', 'Artifact', 'Enchantment', 'Planeswalker', 'Battle', 'Instant', 'Sorcery', 'Kindred']
 
     // Reset form when modal opens/closes
     useEffect(() => {
@@ -61,9 +68,29 @@ export default function AddCardModal({
             setCardQuantity(1)
             setCardType('library')
             setSearchQuery('')
+            setSearchFilters({})
             setSearchInCollection(true)
         }
-    }, [isOpen])
+    }, [isOpen, setSearchFilters, setSearchInCollection, setSearchQuery])
+
+    useEffect(() => {
+        if (!isOpen) return
+
+        const loadSetOptions = async () => {
+            setIsLoadingSetOptions(true)
+            try {
+                const options = await getCardSets(searchInCollection)
+                setSetOptions(options)
+            } catch (error) {
+                console.error('Failed to load set options:', error)
+                setSetOptions([])
+            } finally {
+                setIsLoadingSetOptions(false)
+            }
+        }
+
+        loadSetOptions()
+    }, [isOpen, searchInCollection])
 
     // Effect to automatically set cardType to library when no special options are selected
     useEffect(() => {
@@ -274,6 +301,50 @@ export default function AddCardModal({
                             placeholder={searchInCollection ? "Search your collection..." : "Search all Magic cards..."}
                             className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
                         />
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                                Filter by Set
+                            </label>
+                            <select
+                                value={searchFilters.set || ''}
+                                onChange={(e) => setSearchFilters({
+                                    ...searchFilters,
+                                    set: e.target.value || undefined
+                                })}
+                                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                                disabled={isLoadingSetOptions}
+                            >
+                                <option value="">All Sets</option>
+                                {setOptions.map((set) => (
+                                    <option key={set.code} value={set.code}>
+                                        {set.name} ({set.code})
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                                Filter by Type
+                            </label>
+                            <select
+                                value={searchFilters.type || ''}
+                                onChange={(e) => setSearchFilters({
+                                    ...searchFilters,
+                                    type: e.target.value || undefined
+                                })}
+                                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                            >
+                                <option value="">All Types</option>
+                                {typeOptions.map((type) => (
+                                    <option key={type} value={type}>
+                                        {type}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
                     </div>
 
                     {/* Card Selection */}

--- a/src/components/DeckDetail.tsx
+++ b/src/components/DeckDetail.tsx
@@ -18,6 +18,8 @@ export default function DeckDetail() {
         allCards,
         searchQuery,
         setSearchQuery,
+        searchFilters,
+        setSearchFilters,
         searchInCollection,
         setSearchInCollection,
         isSearchingAllCards,
@@ -101,6 +103,8 @@ export default function DeckDetail() {
                     allCards={allCards}
                     searchQuery={searchQuery}
                     setSearchQuery={setSearchQuery}
+                    searchFilters={searchFilters}
+                    setSearchFilters={setSearchFilters}
                     searchInCollection={searchInCollection}
                     setSearchInCollection={setSearchInCollection}
                     isSearchingAllCards={isSearchingAllCards}

--- a/src/components/DeckDetailModals.tsx
+++ b/src/components/DeckDetailModals.tsx
@@ -1,6 +1,6 @@
 import AddCardModal from './AddCardModal'
 import EditCardModal from './EditCardModal'
-import { Deck, DeckCard, DeckCardType, Card } from '../lib/types'
+import { Deck, DeckCard, DeckCardType, Card, CardFilters } from '../lib/types'
 
 interface DeckDetailModalsProps {
     // Add Card Modal Props
@@ -23,6 +23,8 @@ interface DeckDetailModalsProps {
     allCards: Card[]
     searchQuery: string
     setSearchQuery: (query: string) => void
+    searchFilters: Pick<CardFilters, 'set' | 'type'>
+    setSearchFilters: (filters: Pick<CardFilters, 'set' | 'type'>) => void
     searchInCollection: boolean
     setSearchInCollection: (searchInCollection: boolean) => void
     isSearchingAllCards: boolean
@@ -44,6 +46,8 @@ interface DeckDetailModalsProps {
     allCards,
     searchQuery,
     setSearchQuery,
+    searchFilters,
+    setSearchFilters,
     searchInCollection,
     setSearchInCollection,
     isSearchingAllCards,
@@ -65,6 +69,8 @@ interface DeckDetailModalsProps {
                 allCards={allCards}
                 searchQuery={searchQuery}
                 setSearchQuery={setSearchQuery}
+                searchFilters={searchFilters}
+                setSearchFilters={setSearchFilters}
                 searchInCollection={searchInCollection}
                 setSearchInCollection={setSearchInCollection}
                 isSearchingAllCards={isSearchingAllCards}

--- a/src/hooks/useDeckDetail.ts
+++ b/src/hooks/useDeckDetail.ts
@@ -8,7 +8,7 @@ import {
     getUserCollection,
     searchCards
 } from '../lib/api'
-import { Deck, DeckCard, Card, DeckCardType } from '../lib/types'
+import { Deck, DeckCard, Card, DeckCardType, CardFilters } from '../lib/types'
 import { calculateDeckStats, DeckStats } from '../lib/deckStats'
 import { getDeckValidationStatus } from '../lib/deckConstraints'
 import { useErrorHandler } from './useErrorHandler'
@@ -21,6 +21,7 @@ export function useDeckDetail(deckId: string | undefined) {
     const [availableCards, setAvailableCards] = useState<Card[]>([])
     const [allCards, setAllCards] = useState<Card[]>([])
     const [searchQuery, setSearchQuery] = useState('')
+    const [searchFilters, setSearchFilters] = useState<Pick<CardFilters, 'set' | 'type'>>({})
     const [searchInCollection, setSearchInCollection] = useState(true)
     const [isSearchingAllCards, setIsSearchingAllCards] = useState(false)
     const [isLoadingCollectionCards, setIsLoadingCollectionCards] = useState(false)
@@ -64,14 +65,22 @@ export function useDeckDetail(deckId: string | undefined) {
         })
     }, [deckId])
 
-    const loadAvailableCards = useCallback((query: string = '', page: number = 1, append: boolean = false) => {
+    const loadAvailableCards = useCallback((
+        query: string = '',
+        page: number = 1,
+        append: boolean = false,
+        filters: Pick<CardFilters, 'set' | 'type'> = searchFilters
+    ) => {
         setIsLoadingCollectionCards(true)
         
         withLoading('cards', async () => {
             try {
-                const filters = query.trim() ? { searchQuery: query } : {}
                 const pageSize = 30
-                const result = await getUserCollection(filters, pageSize, page)
+                const collectionFilters: CardFilters = {
+                    ...filters,
+                    searchQuery: query.trim() || undefined
+                }
+                const result = await getUserCollection(collectionFilters, pageSize, page)
                 
                 if (append) {
                     setAvailableCards(prev => [...prev, ...result])
@@ -88,16 +97,16 @@ export function useDeckDetail(deckId: string | undefined) {
                 setIsLoadingCollectionCards(false)
             }
         })
-    }, [])
+    }, [searchFilters])
 
     // Load more collection cards (for pagination)
     const loadMoreCollectionCards = useCallback(() => {
         if (hasMoreCollectionCards && !isLoadingCollectionCards) {
             const nextPage = collectionPage + 1
             setCollectionPage(nextPage)
-            loadAvailableCards(debouncedSearchQuery, nextPage, true)
+            loadAvailableCards(debouncedSearchQuery, nextPage, true, searchFilters)
         }
-    }, [hasMoreCollectionCards, isLoadingCollectionCards, collectionPage, debouncedSearchQuery])
+    }, [hasMoreCollectionCards, isLoadingCollectionCards, collectionPage, debouncedSearchQuery, searchFilters, loadAvailableCards])
 
     // Load deck and cards on component mount
     useEffect(() => {
@@ -117,9 +126,9 @@ export function useDeckDetail(deckId: string | undefined) {
     useEffect(() => {
         if (searchInCollection && debouncedSearchQuery !== undefined) {
             setCollectionPage(1)
-            loadAvailableCards(debouncedSearchQuery, 1, false)
+            loadAvailableCards(debouncedSearchQuery, 1, false, searchFilters)
         }
-    }, [searchInCollection, debouncedSearchQuery])
+    }, [searchInCollection, debouncedSearchQuery, searchFilters, loadAvailableCards])
 
     // Reset collection state when switching search modes
     useEffect(() => {
@@ -127,9 +136,9 @@ export function useDeckDetail(deckId: string | undefined) {
             setCollectionPage(1)
             setAvailableCards([])
             setHasMoreCollectionCards(true)
-            loadAvailableCards('', 1, false)
+            loadAvailableCards('', 1, false, searchFilters)
         }
-    }, [searchInCollection])
+    }, [searchInCollection, searchFilters, loadAvailableCards])
 
     // Calculate deck statistics
     useEffect(() => {
@@ -138,7 +147,10 @@ export function useDeckDetail(deckId: string | undefined) {
     }, [deckCards])
 
     // Search all cards function
-    const searchAllCards = useCallback(async (query: string) => {
+    const searchAllCards = useCallback(async (
+        query: string,
+        filters: Pick<CardFilters, 'set' | 'type'> = searchFilters
+    ) => {
         if (!query.trim()) {
             setAllCards([])
             return
@@ -146,7 +158,7 @@ export function useDeckDetail(deckId: string | undefined) {
 
         setIsSearchingAllCards(true)
         try {
-            const results = await searchCards(query, {}, 20, 1)
+            const results = await searchCards(query, filters, 20, 1)
             setAllCards(results)
         } catch (error) {
             handleError(error, 'Failed to search all cards')
@@ -154,16 +166,16 @@ export function useDeckDetail(deckId: string | undefined) {
         } finally {
             setIsSearchingAllCards(false)
         }
-    }, [])
+    }, [searchFilters])
 
     // Effect for searching all cards when toggle is off and query changes
     useEffect(() => {
         if (!searchInCollection && debouncedSearchQuery.trim()) {
-            searchAllCards(debouncedSearchQuery)
+            searchAllCards(debouncedSearchQuery, searchFilters)
         } else if (!searchInCollection) {
             setAllCards([])
         }
-    }, [searchInCollection, debouncedSearchQuery])
+    }, [searchInCollection, debouncedSearchQuery, searchFilters, searchAllCards])
 
     // Handle adding card to deck
     const handleAddCard = useCallback(async (card: Card, quantity: number, type: DeckCardType) => {
@@ -235,6 +247,8 @@ export function useDeckDetail(deckId: string | undefined) {
         allCards,
         searchQuery,
         setSearchQuery,
+        searchFilters,
+        setSearchFilters,
         searchInCollection,
         setSearchInCollection,
         isSearchingAllCards,


### PR DESCRIPTION
The add-to-deck flow was not applying set and type filters correctly. Set matching in `/api/cards` was case-sensitive, and type matching required an exact `type_line` match, so common values like `Creature` failed against values like `Creature - Human`.

## What changed
- Added set/type filter state to the deck detail add-card search flow.
- Added set/type filter controls in `AddCardModal`.
- Wired the filters through collection search and all-cards search in `useDeckDetail`.
- Updated `/api/cards` filtering in `pocketbase/pb_hooks/api.pb.js` to:
  - match set codes case-insensitively
  - match card type as a case-insensitive partial match

## Reproduction and retest
- Recreated the original predicate behavior with an isolated SQLite repro (`oldPredicateMatches: 0`) and verified the fixed predicate matches (`newPredicateMatches: 1`).
- Rebuilt the app successfully with `npm run build`.

Closes #22