### PR TITLE
Fix Scryfall sync request headers

### DIFF
--- a/pocketbase/pb_hooks/sync.js
+++ b/pocketbase/pb_hooks/sync.js
@@ -31,7 +31,8 @@ function makeRequest(url, retries = MAX_RETRIES) {
             url: url,
             method: "GET",
             headers: {
-                "User-Agent": "Spell-Binder/1.0"
+                "User-Agent": "Spell-Binder/1.0",
+                "Accept": "application/json"
             },
             timeout: 30
         })


### PR DESCRIPTION
Scryfall rejected bulk sync requests with HTTP 400 because the request included a `User-Agent` header but did not explicitly send `Accept`. This makes the bulk sync request compliant with Scryfall's API requirements so scheduled and manual syncs do not fail on that validation.

## What changed
- add `Accept: application/json` to the shared bulk sync request helper in `pocketbase/pb_hooks/sync.js`
- keep the existing `User-Agent` header and retry behavior unchanged

## Notes
This is a targeted fix for the bulk data request path. The image download path already sends an explicit `Accept` header.